### PR TITLE
feat: focus search input on sidebar close

### DIFF
--- a/modules/website/src/app/components/search/search.tsx
+++ b/modules/website/src/app/components/search/search.tsx
@@ -5,12 +5,20 @@ import { searchClient } from '@/app/utils/algolia';
 import { Configure, InstantSearch } from 'react-instantsearch';
 import CustomHits from './hits';
 import CustomSearchbox from './searchbox';
-import { useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { BrefHit } from '@/app/types';
 import Sidebar from '../sidebar';
 
 const Search = () => {
   const [selectedVideo, setSelectedVideo] = useState<BrefHit | null>(null);
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  useEffect(() => {
+    if (!selectedVideo) {
+      inputRef.current?.focus();
+    }
+  }, [selectedVideo]);
+
   return (
     <div className="grid p-8">
       <InstantSearch
@@ -18,7 +26,7 @@ const Search = () => {
         indexName={process.env.NEXT_PUBLIC_ALG_INDEX_NAME!}
       >
         <Configure hitsPerPage={18} />
-        <CustomSearchbox />
+        <CustomSearchbox inputRef={inputRef} />
         <div
           className={cx('grid gap-4', {
             'grid-cols-1': !selectedVideo,

--- a/modules/website/src/app/components/search/searchbox.tsx
+++ b/modules/website/src/app/components/search/searchbox.tsx
@@ -1,11 +1,14 @@
-import { useRef, useState } from 'react';
+import { RefObject, useState } from 'react';
 import { useInstantSearch, useSearchBox } from 'react-instantsearch';
 
-const CustomSearchbox = () => {
+type CustomSearchboxProps = {
+  inputRef: RefObject<HTMLInputElement | null>;
+};
+
+const CustomSearchbox = ({ inputRef }: CustomSearchboxProps) => {
   const { query, refine } = useSearchBox();
   const { status } = useInstantSearch();
   const [inputValue, setInputValue] = useState(query);
-  const inputRef = useRef(null);
 
   const isSearchStalled = status === 'stalled';
 
@@ -26,9 +29,7 @@ const CustomSearchbox = () => {
           event.preventDefault();
           event.stopPropagation();
 
-          if (inputRef.current) {
-            (inputRef.current as HTMLInputElement).blur();
-          }
+          inputRef.current?.blur();
         }}
         onReset={(event) => {
           event.preventDefault();
@@ -36,9 +37,7 @@ const CustomSearchbox = () => {
 
           setQuery('');
 
-          if (inputRef.current) {
-            (inputRef.current as HTMLInputElement).focus();
-          }
+          inputRef.current?.focus();
         }}
       >
         <input


### PR DESCRIPTION
This focuses back the search input when closing the sidebar, so you don't have to click it to perform another search.